### PR TITLE
Provide options to suppress commits and issues on upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ you wish to upgrade. `upgrade` uses the following configuration properties:
 | `bomr.upgrade.prohibited.[].project`  | Project identifier, based on its version property in the bom |
 | `bomr.upgrade.prohibited.[].versions` | List of prohibited versions                    |
 
-The command takes two options:
+The command takes three options:
 
 ```
 Usage: bomr upgrade [<options>]
@@ -155,7 +155,8 @@ Usage: bomr upgrade [<options>]
 Option                Description
 ------                -----------
 --milestone <String>  Milestone to which upgrade issues are assigned
---dry-run             Run upgrade logic without creating issues or doing commits
+--no-commits          Suppress the creation of commits during the upgrade
+--no-issues           Suppress the creation of issues during the upgrade
 ```
 
 For example, to upgrade a bom and assign issues to the `2.0.5` milestone:

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ you wish to upgrade. `upgrade` uses the following configuration properties:
 | `bomr.upgrade.prohibited.[].project`  | Project identifier, based on its version property in the bom |
 | `bomr.upgrade.prohibited.[].versions` | List of prohibited versions                    |
 
-The command takes a single option:
+The command takes two options:
 
 ```
 Usage: bomr upgrade [<options>]
@@ -155,9 +155,10 @@ Usage: bomr upgrade [<options>]
 Option                Description
 ------                -----------
 --milestone <String>  Milestone to which upgrade issues are assigned
+--dry                 Run upgrade logic without creating issues or doing commits
 ```
 
-For example, to upgrade a bom and assign isses to the `2.0.5` milestone:
+For example, to upgrade a bom and assign issues to the `2.0.5` milestone:
 
 ```
 $ bomr.jar upgrade --milestone=2.0.5

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Usage: bomr upgrade [<options>]
 Option                Description
 ------                -----------
 --milestone <String>  Milestone to which upgrade issues are assigned
---dry                 Run upgrade logic without creating issues or doing commits
+--dry-run             Run upgrade logic without creating issues or doing commits
 ```
 
 For example, to upgrade a bom and assign issues to the `2.0.5` milestone:

--- a/src/main/java/io/spring/bomr/upgrade/BomUpgrader.java
+++ b/src/main/java/io/spring/bomr/upgrade/BomUpgrader.java
@@ -29,6 +29,7 @@ import io.spring.bomr.github.Milestone;
  * Handles the process of upgrading the versions of the dependencies managed by a bom.
  *
  * @author Andy Wilkinson
+ * @author Christoph Dreis
  */
 final class BomUpgrader {
 
@@ -48,9 +49,29 @@ final class BomUpgrader {
 		this.prohibitedVersions = prohibitedVersions;
 	}
 
-	void upgrade(File bomFile, String organization, String repositoryName, List<String> labels, String milestoneName,
-			boolean dryRun) {
-		GitHubRepository repository = this.gitHub.getRepository(organization, repositoryName);
+	void upgrade(File bomFile, String organization, String repositoryName, List<String> issueLabels,
+			String milestoneName, boolean commitsEnabled, boolean issuesEnabled) {
+		GitHubRepository repository = getRepository(organization, repositoryName, issuesEnabled);
+		validateLabels(repository, issueLabels);
+		Milestone milestone = determineMilestone(repository, milestoneName);
+		Bom bom = new Bom(bomFile);
+		List<Upgrade> upgrades = new InteractiveUpgradeResolver(this.versionResolver, this.upgradePolicy,
+				this.prohibitedVersions).resolveUpgrades(bom.getManagedProjects().values());
+		upgrades.forEach((upgrade) -> applyUpgrade(upgrade, bom, repository, issueLabels, milestone, commitsEnabled,
+				issuesEnabled));
+	}
+
+	private GitHubRepository getRepository(String organization, String repositoryName, boolean issuesEnabled) {
+		if (!issuesEnabled) {
+			return null;
+		}
+		return this.gitHub.getRepository(organization, repositoryName);
+	}
+
+	private void validateLabels(GitHubRepository repository, List<String> labels) {
+		if (repository == null) {
+			return;
+		}
 		List<String> availableLabels = repository.getLabels();
 		if (!availableLabels.containsAll(labels)) {
 			List<String> unknownLabels = new ArrayList<>(labels);
@@ -58,15 +79,10 @@ final class BomUpgrader {
 			unknownLabels.forEach((label) -> System.err.println("Unknown label '" + label + "'"));
 			System.exit(1);
 		}
-		Milestone milestone = determineMilestone(repository, milestoneName);
-		Bom bom = new Bom(bomFile);
-		List<Upgrade> upgrades = new InteractiveUpgradeResolver(this.versionResolver, this.upgradePolicy,
-				this.prohibitedVersions).resolveUpgrades(bom.getManagedProjects().values());
-		upgrades.forEach((upgrade) -> applyUpgrade(upgrade, bom, repository, labels, milestone, dryRun));
 	}
 
 	private Milestone determineMilestone(GitHubRepository repository, String milestoneName) {
-		if (milestoneName == null) {
+		if (milestoneName == null || repository == null) {
 			return null;
 		}
 		List<Milestone> milestones = repository.getMilestones();
@@ -80,14 +96,23 @@ final class BomUpgrader {
 	}
 
 	private void applyUpgrade(Upgrade upgrade, Bom bom, GitHubRepository repository, List<String> labels,
-			Milestone milestone, boolean dryRun) {
+			Milestone milestone, boolean commitsEnabled, boolean issuesEnabled) {
 		bom.applyUpgrade(upgrade);
-		if (dryRun) {
+		if (!commitsEnabled && !issuesEnabled) {
 			return;
 		}
-		String description = "Upgrade to " + upgrade.getProject().getName() + " " + upgrade.getVersion();
-		int issueNumber = repository.openIssue(description, labels, milestone);
-		bom.commit(description + "\n\nCloses gh-" + issueNumber);
+		String description = createUpgradeDescription(upgrade);
+		if (issuesEnabled) {
+			int issueNumber = repository.openIssue(description, labels, milestone);
+			description = description + "\n\nCloses gh-" + issueNumber;
+		}
+		if (commitsEnabled) {
+			bom.commit(description);
+		}
+	}
+
+	private String createUpgradeDescription(Upgrade upgrade) {
+		return "Upgrade to " + upgrade.getProject().getName() + " " + upgrade.getVersion();
 	}
 
 }

--- a/src/main/java/io/spring/bomr/upgrade/UpgradeCommand.java
+++ b/src/main/java/io/spring/bomr/upgrade/UpgradeCommand.java
@@ -76,7 +76,8 @@ final class UpgradeCommand implements Command {
 		new BomUpgrader(this.gitHub, new MavenMetadataVersionResolver(Arrays.asList("https://repo1.maven.org/maven2/")),
 				this.properties.getPolicy(), this.properties.getProhibited()).upgrade(this.bom,
 						this.properties.getGithub().getOrganization(), this.properties.getGithub().getRepository(),
-						this.properties.getGithub().getIssueLabels(), arguments.getMilestone(), arguments.isDryRun());
+						this.properties.getGithub().getIssueLabels(), arguments.getMilestone(),
+						arguments.commitsEnabled(), arguments.issuesEnabled());
 	}
 
 }

--- a/src/main/java/io/spring/bomr/upgrade/UpgradeCommand.java
+++ b/src/main/java/io/spring/bomr/upgrade/UpgradeCommand.java
@@ -59,7 +59,7 @@ final class UpgradeCommand implements Command {
 			System.err.println();
 			System.err.println("Fatal: bomr.bom has not been configured");
 			System.err.println();
-			System.err.println("Check your onfiguration in .bomr/bomr.(properties|yaml)");
+			System.err.println("Check your configuration in .bomr/bomr.(properties|yaml)");
 			System.err.println();
 			System.exit(-1);
 		}
@@ -69,14 +69,14 @@ final class UpgradeCommand implements Command {
 			System.err.println();
 			System.err.println("  " + this.bom.getAbsolutePath());
 			System.err.println();
-			System.err.println("Check your onfiguration in .bomr/bomr.(properties|yaml)");
+			System.err.println("Check your configuration in .bomr/bomr.(properties|yaml)");
 			System.err.println();
 			System.exit(-1);
 		}
 		new BomUpgrader(this.gitHub, new MavenMetadataVersionResolver(Arrays.asList("https://repo1.maven.org/maven2/")),
 				this.properties.getPolicy(), this.properties.getProhibited()).upgrade(this.bom,
 						this.properties.getGithub().getOrganization(), this.properties.getGithub().getRepository(),
-						this.properties.getGithub().getIssueLabels(), arguments.getMilestone());
+						this.properties.getGithub().getIssueLabels(), arguments.getMilestone(), arguments.isDryRun());
 	}
 
 }

--- a/src/main/java/io/spring/bomr/upgrade/UpgradeCommandArguments.java
+++ b/src/main/java/io/spring/bomr/upgrade/UpgradeCommandArguments.java
@@ -46,14 +46,14 @@ final class UpgradeCommandArguments {
 		ArgumentAcceptingOptionSpec<String> milestoneSpec = optionParser
 				.accepts("milestone", "Milestone to which upgrade issues are assigned").withRequiredArg()
 				.ofType(String.class);
-		OptionSpec<Void> drySpec = optionParser.accepts("dry",
+		OptionSpec<Void> dryRunSpec = optionParser.accepts("dry-run",
 				"Run upgrade logic without creating issues or doing commits");
 		try {
 			OptionSet parsed = optionParser.parse(args);
 			if (parsed.nonOptionArguments().size() != 0) {
 				showUsageAndExit(optionParser);
 			}
-			return new UpgradeCommandArguments(parsed.valueOf(milestoneSpec), parsed.has(drySpec));
+			return new UpgradeCommandArguments(parsed.valueOf(milestoneSpec), parsed.has(dryRunSpec));
 		}
 		catch (Exception ex) {
 			showUsageAndExit(optionParser);

--- a/src/main/java/io/spring/bomr/upgrade/UpgradeCommandArguments.java
+++ b/src/main/java/io/spring/bomr/upgrade/UpgradeCommandArguments.java
@@ -33,11 +33,14 @@ final class UpgradeCommandArguments {
 
 	private final String milestone;
 
-	private final boolean dryRun;
+	private final boolean commitsEnabled;
 
-	private UpgradeCommandArguments(String milestone, boolean dryRun) {
+	private final boolean issuesEnabled;
+
+	private UpgradeCommandArguments(String milestone, boolean commitsEnabled, boolean issuesEnabled) {
 		this.milestone = milestone;
-		this.dryRun = dryRun;
+		this.commitsEnabled = commitsEnabled;
+		this.issuesEnabled = issuesEnabled;
 	}
 
 	static UpgradeCommandArguments parse(String[] args) {
@@ -46,14 +49,17 @@ final class UpgradeCommandArguments {
 		ArgumentAcceptingOptionSpec<String> milestoneSpec = optionParser
 				.accepts("milestone", "Milestone to which upgrade issues are assigned").withRequiredArg()
 				.ofType(String.class);
-		OptionSpec<Void> dryRunSpec = optionParser.accepts("dry-run",
-				"Run upgrade logic without creating issues or doing commits");
+		OptionSpec<Void> noCommitsSpec = optionParser.accepts("no-commits",
+				"Suppress the creation of commits during the upgrade");
+		OptionSpec<Void> noIssuesSpec = optionParser.accepts("no-issues",
+				"Suppress the creation of issues during the upgrade");
 		try {
 			OptionSet parsed = optionParser.parse(args);
 			if (parsed.nonOptionArguments().size() != 0) {
 				showUsageAndExit(optionParser);
 			}
-			return new UpgradeCommandArguments(parsed.valueOf(milestoneSpec), parsed.has(dryRunSpec));
+			return new UpgradeCommandArguments(parsed.valueOf(milestoneSpec), !parsed.has(noCommitsSpec),
+					!parsed.has(noIssuesSpec));
 		}
 		catch (Exception ex) {
 			showUsageAndExit(optionParser);
@@ -78,8 +84,12 @@ final class UpgradeCommandArguments {
 		return this.milestone;
 	}
 
-	boolean isDryRun() {
-		return this.dryRun;
+	boolean commitsEnabled() {
+		return this.commitsEnabled;
+	}
+
+	boolean issuesEnabled() {
+		return this.issuesEnabled;
 	}
 
 }

--- a/src/main/java/io/spring/bomr/upgrade/UpgradeCommandArguments.java
+++ b/src/main/java/io/spring/bomr/upgrade/UpgradeCommandArguments.java
@@ -22,6 +22,7 @@ import joptsimple.ArgumentAcceptingOptionSpec;
 import joptsimple.BuiltinHelpFormatter;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
 
 /**
  * Command line arguments for the {@link UpgradeCommand}.
@@ -32,8 +33,11 @@ final class UpgradeCommandArguments {
 
 	private final String milestone;
 
-	private UpgradeCommandArguments(String milestone) {
+	private final boolean dryRun;
+
+	private UpgradeCommandArguments(String milestone, boolean dryRun) {
 		this.milestone = milestone;
+		this.dryRun = dryRun;
 	}
 
 	static UpgradeCommandArguments parse(String[] args) {
@@ -42,12 +46,14 @@ final class UpgradeCommandArguments {
 		ArgumentAcceptingOptionSpec<String> milestoneSpec = optionParser
 				.accepts("milestone", "Milestone to which upgrade issues are assigned").withRequiredArg()
 				.ofType(String.class);
+		OptionSpec<Void> drySpec = optionParser.accepts("dry",
+				"Run upgrade logic without creating issues or doing commits");
 		try {
 			OptionSet parsed = optionParser.parse(args);
 			if (parsed.nonOptionArguments().size() != 0) {
 				showUsageAndExit(optionParser);
 			}
-			return new UpgradeCommandArguments(parsed.valueOf(milestoneSpec));
+			return new UpgradeCommandArguments(parsed.valueOf(milestoneSpec), parsed.has(drySpec));
 		}
 		catch (Exception ex) {
 			showUsageAndExit(optionParser);
@@ -70,6 +76,10 @@ final class UpgradeCommandArguments {
 
 	String getMilestone() {
 		return this.milestone;
+	}
+
+	boolean isDryRun() {
+		return this.dryRun;
 	}
 
 }


### PR DESCRIPTION
Hi.

I was playing with `bomr upgrade` the other day and found it extremly helpful to have some sort of dry run option to review stuff even before it was committed. So this PR adds a `--dry` option to the upgrade command plus some related polishing. This new option could also help projects without GitHub integration for the time being. They could run the `--dry` upgrade and do the issue creation and commits manually.

I'm not super happy with the name of the new option, but `dry` was the closest to what it actually does. If you have a suggestion, I'm more than happy to change it.

Let me know what you think.
Cheers,
Christoph