### PR TITLE
Update build instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ CLI tool for maintaining a Maven bom.
 
 ## Building
 
-Bomr requires Java 8 and is built with Maven:
+Bomr requires Java 8 and is built with Gradle:
 
 ```
-./mvnw clean package
+./gradlew clean build
 ```
 
 ## Running


### PR DESCRIPTION
Hi,

I noticed while playing around that the README still refers to Maven, although the tool is built with Gradle. This PR updates the README accordingly.

Cheers,
Christoph